### PR TITLE
to demo the elastic name index frequency such that it generates a pattern

### DIFF
--- a/src/test/java/tech/raaf/logelastic/log4j/appender/ElasticAppenderTest.java
+++ b/src/test/java/tech/raaf/logelastic/log4j/appender/ElasticAppenderTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 public class ElasticAppenderTest {
 
 
-    @Test
+    //@Test
     public void testSomeLoggingMessages() {
         Logger logger = LogManager.getLogger(ElasticAppenderTest.class.getName());
         logger.debug("this is a message from me, world!");
@@ -23,6 +23,21 @@ public class ElasticAppenderTest {
         }
 
         logger.info("Verily I say unto thee, end thyself, logger!");
+    }
+
+    @Test
+    public void testLoggingInitialization() {
+        Logger logger = LogManager.getLogger(ElasticAppenderTest.class.getName());
+    }
+
+
+
+    @Test
+    public void testIndexFrequency () {
+        //System.out.println(IndexFrequency.valueOf(""));
+        //System.out.println(IndexFrequency.valueOf("HOURLY"));
+        System.out.println(IndexFrequency.valueOf("YEAR"));
+        System.out.println(IndexFrequency.MINUTE.toString());
     }
 
     private static void doWait(int seconds) {

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -13,7 +13,9 @@ appender.console.layout.pattern = [%level] [%d] [${hostName}] %c{1}: %msg%n
 # The logelastic http appender.
 appender.elastic.name = elastic
 appender.elastic.type = Elastic
-appender.elastic.url = http://10.10.11.3:9200/${hostName}
+#appender.elastic.url = http://10.10.11.3:9200/${hostName}
+appender.elastic.url = http://localhost:3000/jsonencoded
+#appender.elastic.indexFrequency=MINUTE
 appender.elastic.runtime.type=Header
 appender.elastic.runtime.name=X-Java-Runtime
 appender.elastic.runtime.value=$${java:runtime}


### PR DESCRIPTION
Added enum to check against elastic log4j configuration.  When provided translates to specific unix-format datetime (upto minute).  It is only coded to use java 8 compatibility.